### PR TITLE
Update appveyor to use latest stable versions of DMD and LDC.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,201 +2,89 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
-    DVersion: 2.081.1
+    DVersion: stable
     arch: x64
   - DC: dmd
-    DVersion: 2.081.1
-    arch: x86
-  - DC: dmd
-    DVersion: 2.080.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.079.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.078.3
-    arch: x64
-  - DC: dmd
-    DVersion: 2.077.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.076.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.075.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.074.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.073.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.072.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.071.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.070.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.069.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.068.2
-    arch: x64
-  - DC: dmd
-    DVersion: 2.067.1
-    arch: x64
-  - DC: dmd
-    DVersion: 2.066.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.10.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.9.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.9.0
+    DVersion: stable
     arch: x86
   - DC: ldc
-    DVersion: 1.8.0
-    arch: x64
+    DVersion: stable
+    arch: x86
   - DC: ldc
-    DVersion: 1.7.0
+    DVersion: stable
     arch: x64
-  - DC: ldc
-    DVersion: 1.6.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.5.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.4.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.3.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.2.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.1.0
-    arch: x64
-  - DC: ldc
-    DVersion: 1.0.0
-    arch: x64
-matrix:
-  allow_failures:
-    # I'm getting weird occasional errors of...
-    #    LINK : fatal error LNK1104: cannot open file 'shell32.lib'
-    # ...just with this compiler version, and only on Windows/AppVeyor.
-    - DC: dmd
-      DVersion: 2.068.2
 
 skip_tags: true
 
 install:
-  - ps: function ResolveDMD
+  - ps: function ResolveLatestDMD
         {
             $version = $env:DVersion;
             if($version -eq "stable") {
                 $latest = (Invoke-WebRequest "http://downloads.dlang.org/releases/LATEST").toString();
-                $urls = @("http://downloads.dlang.org/releases/2.x/$($latest)/dmd.$($latest).windows.7z",
-                          "http://ftp.digitalmars.com/dmd.$($latest).windows.7z");
+                $url = "http://downloads.dlang.org/releases/2.x/$($latest)/dmd.$($latest).windows.7z";
             }elseif($version -eq "beta") {
                 $latest = (Invoke-WebRequest "http://downloads.dlang.org/pre-releases/LATEST").toString();
                 $latestVersion = $latest.split("-")[0].split("~")[0];
-                $urls = @("http://downloads.dlang.org/pre-releases/2.x/$($latestVersion)/dmd.$($latest).windows.7z",
-                          "http://ftp.digitalmars.com/dmd.$($latest).windows.7z");
+                $url = "http://downloads.dlang.org/pre-releases/2.x/$($latestVersion)/dmd.$($latest).windows.7z";
             }elseif($version -eq "nightly") {
-                $latest = (Invoke-WebRequest "http://nightlies.dlang.org/$($version)/LATEST").toString();
-                $urls = @("http://nightlies.dlang.org/dmd-$($latest)/dmd.master.windows.7z");
+                $url = "http://nightlies.dlang.org/dmd-master-2017-05-20/dmd.master.windows.7z"
             }else {
-                $urls = @("http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z",
-                          "http://ftp.digitalmars.com/dmd.$($version).windows.7z");
+                $url = "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z";
             }
-            $env:PATH += ";C:\dmd2\windows\bin;";
-            return $urls;
+            if($env:arch -eq "x64"){
+                $env:PATH += ";C:\dmd2\windows\bin64;";
+            } else {
+                $env:PATH += ";C:\dmd2\windows\bin;";
+            }
+            return $url;
         }
-  - ps: function ResolveLDC
+  - ps: function ResolveLatestLDC
         {
-            if($env:arch -eq "x86"){
-                $archBits = "32";
-            }
-            elseif($env:arch -eq "x64"){
-                $archBits = "64";
-            }
             $version = $env:DVersion;
             $arch = $env:arch;
             if($version -eq "stable") {
                 $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST").toString().replace("`n","").replace("`r","");
-                $urls = @("https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-$($arch).7z");
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-$($arch).7z";
             }elseif($version -eq "beta") {
                 $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST_BETA").toString().replace("`n","").replace("`r","");
-                $urls = @("https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-$($arch).7z");
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-windows-$($arch).7z";
             } else {
                 $latest = $version;
-                $urls = @("https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-windows-$($arch).7z");
-                $urls += "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win$($archBits)-msvc.zip";
+                $url = "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-windows-$($arch).7z";
             }
-            $env:PATH += ";C:\ldc2-$($latest)-windows-$($arch)\bin;C:\ldc2-$($latest)-win$($archBits)-msvc\bin";
+            $env:PATH += ";C:\ldc2-$($latest)-windows-$($arch)\bin";
             $env:DC = "ldc2";
-            return $urls;
+            return $url;
         }
   - ps: function SetUpDCompiler
         {
             $env:toolchain = "msvc";
             if($env:DC -eq "dmd"){
-                $env:DMD = "dmd";
-                $urls = ResolveDMD;
+              echo "downloading ...";
+              $url = ResolveLatestDMD;
+              echo $url;
+              Invoke-WebRequest $url -OutFile "c:\dmd.7z";
+              echo "finished.";
+              pushd c:\\;
+              7z x dmd.7z > $null;
+              popd;
             }
             elseif($env:DC -eq "ldc"){
-                $env:DC = "ldmd2";
-                $env:DMD = "ldmd2";
-                $urls = ResolveLDC;
+              echo "downloading ...";
+              $url = ResolveLatestLDC;
+              echo $url;
+              Invoke-WebRequest $url -OutFile "c:\ldc.zip";
+              echo "finished.";
+              pushd c:\\;
+              7z x ldc.zip > $null;
+              popd;
             }
-            echo "downloading...";
-            echo urls=$urls;
-            foreach($tryUrl in $urls){
-                $dloadOk = $true;
-                echo Trying $tryUrl;
-                try{
-                    Invoke-WebRequest $tryUrl -OutFile "c:\compiler.archive";
-                }
-                catch [Net.WebException]{
-                    $dloadOk = $false;
-                }
-                if($dloadOk -eq $true){
-                    break;
-                }
-            }
-            echo "extracting...";
-            pushd c:\\;
-            7z x compiler.archive > $null;
-            popd;
-            echo "finished.";
         }
   - ps: SetUpDCompiler
-  - powershell -Command Invoke-WebRequest https://code.dlang.org/files/dub-1.9.0-windows-x86.zip -OutFile dub.zip
+  - powershell -Command Invoke-WebRequest http://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
   - 7z x dub.zip -odub > nul
   - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
-  - dub --version
-  # Some older LDC/GDC compilers don't come with rdmd
-  - ps: function SetUpRDMD
-        {
-            if((Get-Command "rdmd.exe" -ErrorAction SilentlyContinue) -eq $null)
-            {
-                Invoke-WebRequest "http://downloads.dlang.org/releases/2.x/2.080.0/dmd.2.080.0.windows.7z" -OutFile "c:\rdmd-dmd.7z";
-                pushd c:\\;
-                7z x -ordmd-dmd rdmd-dmd.7z > $null;
-                popd;
-            }
-        }
-  - ps: SetUpRDMD
-  - set PATH=%PATH%;c:\rdmd-dmd\dmd2\windows\bin
 
 before_build:
   - ps: if($env:arch -eq "x86"){
@@ -210,6 +98,7 @@ before_build:
         }
   - ps: $env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";
   - '"%compilersetup%" %compilersetupargs%'
+  - ps: Get-CIMInstance Win32_OperatingSystem | Select FreePhysicalMemory,TotalVisibleMemory
 
 build_script:
  - echo dummy build script - dont remove me
@@ -220,5 +109,6 @@ test_script:
  - echo %DC%
  - echo %DMD%
  - echo %PATH%
+ - dub --version
  - '%DC% --help'
  - dub test --arch=%Darch% --compiler=%DC%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,18 @@
 platform: x64
 environment:
- matrix:
-  - DC: dmd
-    DVersion: stable
-    arch: x64
-  - DC: dmd
-    DVersion: stable
-    arch: x86
-  - DC: ldc
-    DVersion: stable
-    arch: x86
-  - DC: ldc
-    DVersion: stable
-    arch: x64
+  matrix:
+    - DC: dmd
+      DVersion: stable
+      arch: x64
+    - DC: dmd
+      DVersion: stable
+      arch: x86
+    - DC: ldc
+      DVersion: stable
+      arch: x86
+    - DC: ldc
+      DVersion: stable
+      arch: x64
 
 skip_tags: true
 
@@ -34,9 +34,8 @@ install:
             }
             if($env:arch -eq "x64"){
                 $env:PATH += ";C:\dmd2\windows\bin64;";
-            } else {
-                $env:PATH += ";C:\dmd2\windows\bin;";
             }
+            $env:PATH += ";C:\dmd2\windows\bin;";
             return $url;
         }
   - ps: function ResolveLatestLDC
@@ -82,9 +81,6 @@ install:
             }
         }
   - ps: SetUpDCompiler
-  - powershell -Command Invoke-WebRequest http://code.dlang.org/files/dub-1.11.0-windows-x86.zip -OutFile dub.zip
-  - 7z x dub.zip -odub > nul
-  - set PATH=%CD%\%binpath%;%CD%\dub;%PATH%
 
 before_build:
   - ps: if($env:arch -eq "x86"){


### PR DESCRIPTION
Update appveyor to use latest stable versions of DMD and LDC.
Also, support of DMD64 with DMD >= 2.091.0